### PR TITLE
Update requirements.txt with missing module indexed.py needed on Ubuntu 14.04

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,10 @@
 click
+indexed
+
+Ubuntu 14.04:
+- Pip
+    sudo apt-get install python3-pip
+- Module click
+    sudo pip install click or sudo pip3 install click (for python3)
+- Module indexed.py
+    sudo pip install indexed.py or sudo pip3 install indexed.py (for python3)


### PR DESCRIPTION
I think it's useful to add the requirement of indexed.py module which is not natively installed with python: 
Traceback (most recent call last):
  File "openshs", line 5, in <module>
    from repeater import SamplesPool
  File "/home/chemoun/Documents/openshs-master/app/repeater.py", line 3, in <module>
    from indexed import IndexedOrderedDict
ImportError: No module named indexed
